### PR TITLE
Enhance instructions for tracking .env files

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,25 @@
+Before rewriting history, it’s smart to check whether any .env files are actually committed in your repo history.
+
+1. Check if .env is currently tracked
+```git ls-files | grep .env```
+
+
+- If this prints .env, then it’s currently tracked in your repo.
+
+2. Search the entire git history for .env
+```git log --all -- .env```
+
+- If you see commits listed, that means .env has been committed at some point in history.
+
+3. Grep for .env in the history
+
+- This checks commit messages and file paths:
+
+```git log --stat | grep .env```
+
+4. Scan all commits for the word .env
+```git rev-list --objects --all | grep .env```
+
+- This is the most thorough — it’ll show every commit and object where .env appeared.
+
+ProTip: use ``git show <hash commit>`` to reveal the secret in plain text


### PR DESCRIPTION
This pull request adds a helpful checklist to `notes.md` for identifying whether `.env` files have been committed to a repository's history. The guide covers different git commands to check for `.env` files in both the current state and the entire commit history.

Guidance for finding committed `.env` files:

* Added step-by-step instructions for checking if `.env` is currently tracked using `git ls-files | grep .env`.
* Included commands for searching the git history for `.env` files and commit messages, such as `git log --all -- .env` and `git log --stat | grep .env`.
* Provided a thorough method to scan all commits for `.env` using `git rev-list --objects --all | grep .env`.
* Added a tip for inspecting the contents of a commit with `git show <hash commit>`.